### PR TITLE
Working file picker for Linux

### DIFF
--- a/src/desktop/sbtw.Desktop.Linux/LinuxEditor.cs
+++ b/src/desktop/sbtw.Desktop.Linux/LinuxEditor.cs
@@ -7,6 +7,6 @@ namespace sbtw.Desktop.Linux
 {
     public class LinuxEditor : DesktopEditor
     {
-        protected override Picker CreatePicker() => new NoOpPicker();
+        protected override Picker CreatePicker() => new NfdPicker();
     }
 }

--- a/src/desktop/sbtw.Desktop.Linux/NfdPicker.cs
+++ b/src/desktop/sbtw.Desktop.Linux/NfdPicker.cs
@@ -1,0 +1,152 @@
+// Copyright (c) 2021 Nathan Alo. Licensed under MIT License.
+// See LICENSE in the repository root for more details.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NativeFileDialogs.AutoGen;
+using sbtw.Editor.Platform;
+
+namespace sbtw.Desktop.Linux
+{
+    public class NfdPicker : Picker
+    {
+        private static NfdnfilteritemT[] toNfdFilters(IReadOnlyList<PickerFilter> filters)
+        {
+            return filters.Select((filter, _i) => new NfdnfilteritemT
+            {
+                Name = filter.Description,
+                Spec = string.Join(@",", filter.Files
+                    .Select((file) => file.StartsWith("*.") ? file[2..] : file)),
+            }).ToArray();
+        }
+
+        protected sealed override async Task<IEnumerable<string>> OpenFileAsync(string title, string suggestedPath, IReadOnlyList<PickerFilter> filters, bool allowMultiple)
+        {
+            return await Task.Run(() =>
+            {
+                nfd.NFD_Init();
+
+                NfdnfilteritemT[] nfdFilters = toNfdFilters(filters);
+                string[] files = Array.Empty<string>();
+
+                unsafe
+                {
+                    if (allowMultiple)
+                    {
+                        IntPtr outPathsPtr;
+                        NfdresultT result = nfd.NFD_OpenDialogMultipleN(&outPathsPtr, nfdFilters, (uint)nfdFilters.Length, suggestedPath);
+                        switch (result)
+                        {
+                            case NfdresultT.NFD_OKAY:
+                                uint numPaths = 0;
+                                nfd.NFD_PathSetGetCount(outPathsPtr, ref numPaths);
+                                files = new string[numPaths];
+                                for (uint i = 0; i < numPaths; i++)
+                                {
+                                    sbyte* outPathPtr;
+                                    nfd.NFD_PathSetGetPathN(outPathsPtr, i, &outPathPtr);
+                                    files[i] = new string(outPathPtr);
+                                }
+                                nfd.NFD_PathSetFree(outPathsPtr);
+                                break;
+                            case NfdresultT.NFD_CANCEL:
+                                nfd.NFD_PathSetFree(outPathsPtr);
+                                break;
+                            default:
+                                nfd.NFD_PathSetFree(outPathsPtr);
+                                string err = $@"NFD error: {nfd.NFD_GetError()}";
+                                nfd.NFD_Quit();
+                                throw new IOException(err);
+                        }
+                    }
+                    else
+                    {
+                        sbyte* outPathPtr;
+                        NfdresultT result = nfd.NFD_OpenDialogN(&outPathPtr, nfdFilters, (uint)nfdFilters.Length, suggestedPath);
+                        switch (result)
+                        {
+                            case NfdresultT.NFD_OKAY:
+                                files = new string[] { new string(outPathPtr) };
+                                break;
+                            case NfdresultT.NFD_CANCEL:
+                                break;
+                            default:
+                                string err = $@"NFD error: {nfd.NFD_GetError()}";
+                                nfd.NFD_Quit();
+                                throw new IOException(err);
+                        }
+                    }
+                }
+
+                nfd.NFD_Quit();
+                return files;
+            });
+        }
+
+        protected sealed override async Task<string> OpenFolderAsync(string title, string suggestedPath)
+        {
+            return await Task.Run(() =>
+            {
+                nfd.NFD_Init();
+
+                string folder = null;
+
+                unsafe
+                {
+                    sbyte* outPathPtr;
+                    NfdresultT result = nfd.NFD_PickFolderN(&outPathPtr, suggestedPath);
+                    switch (result)
+                    {
+                        case NfdresultT.NFD_OKAY:
+                            folder = new string(outPathPtr);
+                            break;
+                        case NfdresultT.NFD_CANCEL:
+                            break;
+                        default:
+                            string err = $@"NFD error: {nfd.NFD_GetError()}";
+                            nfd.NFD_Quit();
+                            throw new IOException(err);
+                    }
+                }
+
+                nfd.NFD_Quit();
+                return folder;
+            });
+        }
+
+        protected sealed override async Task<string> SaveFileAsync(string title, string suggestedFileName, string suggestedPath, IReadOnlyList<PickerFilter> filters)
+        {
+            return await Task.Run(() =>
+            {
+                nfd.NFD_Init();
+
+                NfdnfilteritemT[] nfdFilters = toNfdFilters(filters);
+                string folder = null;
+
+                unsafe
+                {
+                    sbyte* savePathPtr;
+                    NfdresultT result = nfd.NFD_SaveDialogN(&savePathPtr, nfdFilters, (uint)nfdFilters.Length, suggestedPath, suggestedFileName);
+                    switch (result)
+                    {
+                        case NfdresultT.NFD_OKAY:
+                            folder = new string(savePathPtr);
+                            break;
+                        case NfdresultT.NFD_CANCEL:
+                            break;
+                        default:
+                            string err = $@"NFD error: {nfd.NFD_GetError()}";
+                            nfd.NFD_Quit();
+                            throw new IOException(err);
+                    }
+                }
+
+                nfd.NFD_Quit();
+                return folder;
+            });
+        }
+    }
+}

--- a/src/desktop/sbtw.Desktop.Linux/ZenityPicker.cs
+++ b/src/desktop/sbtw.Desktop.Linux/ZenityPicker.cs
@@ -9,12 +9,12 @@ namespace sbtw.Desktop.Linux
     public class ZenityPicker : LinuxPicker
     {
         protected override string GetOpenFileCommand(string title, string suggestedPath, IReadOnlyList<PickerFilter> filters, bool allowMultiple)
-            => $@"zenity --title=""{title}"" --filename=""{suggestedPath}""" + $@"{(allowMultiple ? " --multiple" : string.Empty)} --separator=""|""";
+            => $@"zenity --file-selection --title=""{title}"" --filename=""{suggestedPath}""" + $@"{(allowMultiple ? " --multiple" : string.Empty)} --separator=""|""";
 
         protected override string GetOpenFolderCommand(string title, string suggestedPath)
-            => $@"zenity --title=""{title}"" --filename=""{suggestedPath}"" --directory";
+            => $@"zenity --file-selection --title=""{title}"" --filename=""{suggestedPath}"" --directory";
 
         protected override string GetSaveFileCommand(string title, string suggestedFileName, string suggestedPath, IReadOnlyList<PickerFilter> filters)
-            => $@"zenity --title=""{title}"" --filename=""{suggestedPath}"" --save";
+            => $@"zenity --file-selection --title=""{title}"" --filename=""{suggestedPath}"" --save";
     }
 }

--- a/src/desktop/sbtw.Desktop.Linux/sbtw.Desktop.Linux.csproj
+++ b/src/desktop/sbtw.Desktop.Linux/sbtw.Desktop.Linux.csproj
@@ -3,6 +3,12 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NativeFileDialogs.AutoGen" Version="0.1.0-alpha" />
+    <PackageReference Include="NativeFileDialogs.Net.Runtime" Version="0.1.0-alpha" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Both current kDialog and Zenity pickers don't work on Linux. They seem to execute a `bash` command, but fail with the message "cannot execute binary file". It may be due to security/permission reasons.

In any case, I've made a picker using NativeFileDialogs.AutoGen. I put it under the Linux folder, but actually it should also work on Windows.

The library really doesn't look easy to use, because it's the version autogenerated directly from the C code, but at some point later on I'll have a NativeFileDialogs.Net library that nicely wraps around it.